### PR TITLE
[Hotfix] 메인 상품 조회 캐시 60초 설정

### DIFF
--- a/app/api/products/index.ts
+++ b/app/api/products/index.ts
@@ -14,7 +14,9 @@ import { MainPageProductsResponse, ProductDetailResponse, ProductSearchFilter } 
 export async function fetchMainPageProducts(page: number = 0, size: number = 10): Promise<MainPageProductsResponse> {
   try {
     const endpoint = `${API_ENDPOINTS.products.main}?page=${page}&size=${size}`;
-    return await get<MainPageProductsResponse>(endpoint);
+    return await get<MainPageProductsResponse>(endpoint, {
+      next: { revalidate: 60 },
+    });
   } catch (error) {
     console.error('메인 페이지 상품 목록 가져오기 실패:', error);
     throw handleApiError(error);


### PR DESCRIPTION
## PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 스타일 수정
- [ ] 리팩터링

## 이슈 링크

https://~ (지라 작업 링크)

## 수정 사항

- main 페이지 상품 조회 api 캐시 60초 설정

## 기타

- Nextjs 서버 컴포넌트 기본 동작으로 정적 렌더링 사용하여 빌드 시점 또는 첫 요청 시 렌더링된 결과가 캐시된다.
    - 그 결과 DB를 초기화 하여도 캐시된 데이터가 보여지는 이슈 존재
    - Fetch API revalidate 옵션 추가하여 캐시되는 시간 설정