### PR TITLE
추가 이미지 등록 제한 5장으로 설정

### DIFF
--- a/app/admin/_components/ImageUploader.tsx
+++ b/app/admin/_components/ImageUploader.tsx
@@ -5,7 +5,8 @@ import { useFormContext } from 'react-hook-form';
 import { ImageType } from '../_types/product';
 import Image from 'next/image';
 
-const MAX_IMAGE_COUNT = 4;
+const MAX_SUB_IMAGE_COUNT = 4;
+const MAX_ADD_IMAGE_COUNT = 5;
 
 const ImageUploader = () => {
   const { watch, setValue } = useFormContext();
@@ -20,8 +21,12 @@ const ImageUploader = () => {
   const subInputRef = useRef<HTMLInputElement>(null);
   const addInputRef = useRef<HTMLInputElement>(null);
 
-  const showLimitAlert = () => {
-    alert(`최대 ${MAX_IMAGE_COUNT}장까지 업로드할 수 있습니다.`);
+  const showSubImageLimitAlert = () => {
+    alert(`서브 이미지는 최대 ${MAX_SUB_IMAGE_COUNT}장까지 업로드할 수 있습니다.`);
+  };
+
+  const showAddImageLimitAlert = () => {
+    alert(`추가 이미지는 최대 ${MAX_ADD_IMAGE_COUNT}장까지 업로드할 수 있습니다.`);
   };
 
   const handleMainImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,6 +42,13 @@ const ImageUploader = () => {
   const handleSubImagesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     if (!files.length) return;
+
+    const remaining = MAX_SUB_IMAGE_COUNT - subImageFiles.length;
+    if (remaining <= 0) {
+      showSubImageLimitAlert();
+      e.target.value = '';
+      return;
+    }
 
     const updatedSubImages = [...subImages];
     const updatedSubImageFiles = [...subImageFiles];
@@ -60,7 +72,7 @@ const ImageUploader = () => {
       }
     }
 
-    for (let i = 0; i < MAX_IMAGE_COUNT; i++) {
+    for (let i = 0; i < MAX_SUB_IMAGE_COUNT; i++) {
       if (updatedSubImages[i] === undefined && files.length > 0) {
         const file = files.shift();
         if (!file) break;
@@ -83,9 +95,9 @@ const ImageUploader = () => {
     const files = Array.from(e.target.files || []);
     if (!files.length) return;
 
-    const remaining = MAX_IMAGE_COUNT - additionalImageFiles.length;
+    const remaining = MAX_ADD_IMAGE_COUNT - additionalImageFiles.length;
     if (remaining <= 0) {
-      showLimitAlert();
+      showAddImageLimitAlert();
       e.target.value = '';
       return;
     }


### PR DESCRIPTION
## PR 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 스타일 수정
- [x] 리팩터링

## 수정 사항

- 추가 이미지의 등록 제한을 5장으로 설정했습니다.
- 서브 이미지, 추가 이미지 등록 제한을 넘어갈 경우 alert 창을 출력하도록 수정했습니다.

## 기타

- 백오피스 수정 사항은 한 PR에 많은 내용이 담기지 않게 하기 위해 PR을 1개씩 올릴 예정입니다 ! 
