### PR TITLE
fix: 좋아요 페이지 403 권한 에러 수정

### DIFF
--- a/app/api/config/index.ts
+++ b/app/api/config/index.ts
@@ -17,7 +17,6 @@ export const API_CONFIG = {
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
-    Authorization: `Bearer ${localStorage.getItem('accessToken') ?? ''}`,
   },
 
   // 재시도 설정

--- a/app/api/utils/getClientToken.ts
+++ b/app/api/utils/getClientToken.ts
@@ -1,0 +1,4 @@
+export const getClientToken = (): string | null => {
+  const token = localStorage.getItem('accessToken');
+  return token;
+};

--- a/app/api/utils/getServerToken.ts
+++ b/app/api/utils/getServerToken.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+export const getServerToken = async () => {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('accessToken')?.value || '';
+  return token;
+};

--- a/app/api/utils/getToken.ts
+++ b/app/api/utils/getToken.ts
@@ -1,0 +1,13 @@
+import { getClientToken } from './getClientToken';
+import { getServerToken } from './getServerToken';
+
+export const getToken = async () => {
+  // 서버 사이드에서는 getServerToken을 사용
+  if (typeof window === 'undefined') {
+    const serverToken = await getServerToken();
+    return serverToken;
+  }
+  // 클라이언트 사이드에서는 getClientToken을 사용
+  const clientToken = getClientToken();
+  return clientToken;
+};

--- a/app/api/utils/http.ts
+++ b/app/api/utils/http.ts
@@ -2,13 +2,18 @@
 
 import { API_CONFIG, createApiUrl } from '../config';
 import { handleHttpError } from '../error';
+import { getToken } from './getToken';
 
 /**
  * 기본 HTTP 요청 옵션
  */
-export const defaultRequestOptions: RequestInit = {
-  headers: API_CONFIG.headers,
-  // 타임아웃 설정은 AbortController로 구현 가능
+export const getDefaultRequestOptions = async (): Promise<RequestInit> => {
+  const token = await getToken();
+  const headers = {
+    ...API_CONFIG.headers,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  return { headers };
 };
 
 /**
@@ -37,9 +42,10 @@ export async function get<T>(endpoint: string, options?: RequestInit): Promise<T
   const { controller, timeoutId } = createAbortController();
 
   try {
+    const requestOptions = await getDefaultRequestOptions();
     const response = await fetch(url, {
       method: 'GET',
-      ...defaultRequestOptions,
+      ...requestOptions,
       ...options,
       signal: controller.signal,
     });
@@ -71,9 +77,10 @@ export async function post<T>(endpoint: string, data: unknown, options?: Request
   const { controller, timeoutId } = createAbortController();
 
   try {
+    const requestOptions = await getDefaultRequestOptions();
     const response = await fetch(url, {
       method: 'POST',
-      ...defaultRequestOptions,
+      ...requestOptions,
       ...options,
       body: JSON.stringify(data),
       signal: controller.signal,
@@ -106,9 +113,10 @@ export async function patch<T>(endpoint: string, data: unknown, options?: Reques
   const { controller, timeoutId } = createAbortController();
 
   try {
+    const requestOptions = await getDefaultRequestOptions();
     const response = await fetch(url, {
       method: 'PATCH',
-      ...defaultRequestOptions,
+      ...requestOptions,
       ...options,
       body: JSON.stringify(data),
       signal: controller.signal,
@@ -141,9 +149,10 @@ export async function del(endpoint: string, data: unknown, options?: RequestInit
   const { controller, timeoutId } = createAbortController();
 
   try {
+    const requestOptions = await getDefaultRequestOptions();
     const response = await fetch(url, {
       method: 'DELETE',
-      ...defaultRequestOptions,
+      ...requestOptions,
       ...options,
       body: JSON.stringify(data),
       signal: controller.signal,


### PR DESCRIPTION
## PR 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 스타일 수정
- [ ] 리팩터링

## 수정 사항

- 서버 컴포넌트에서 초기 API 요청 시 Authorization 헤더에 토큰이 없어 403 에러 발생.
- 클라이언트는 localStorage에서, 서버는 cookie에서 accessToken을 읽어 헤더에 동적으로 설정하도록 수정함.

