### PR TITLE
fix : QA UI 이슈(자체테스트)

### DIFF
--- a/app/(home)/_components/ProductCard.tsx
+++ b/app/(home)/_components/ProductCard.tsx
@@ -147,7 +147,7 @@ export default function ProductCard({
               mainProduct.shootingSeason.map((season, index) => (
                 <span
                   key={index}
-                  className="text-label2 font-medium text-gray-80 last:border-l last:border-gray-50 last:pl-[0.6rem]"
+                  className="border-r border-gray-50 pr-[0.6rem] text-label2 font-medium text-gray-80 last:border-r-0 last:pr-0"
                 >
                   {season.replace('YEAR_', '').replace('_FIRST_HALF', '년 상반기').replace('_SECOND_HALF', '년 하반기')}
                 </span>

--- a/app/like/_components/ProductCard.tsx
+++ b/app/like/_components/ProductCard.tsx
@@ -111,7 +111,7 @@ export default function ProductCard({ likeProduct, onLikeChange }: ProductCardPr
             {(likeProduct.shootingSeason as ShootingPeriod[]).map((season, index) => (
               <span
                 key={index}
-                className="text-label2 font-medium text-gray-80 last:border-l last:border-gray-50 last:pl-[0.6rem]"
+                className="border-r border-gray-50 pr-[0.6rem] text-label2 font-medium text-gray-80 last:border-r-0 last:pr-0"
               >
                 {SHOOTING_PERIOD_DISPLAY_MAP[season]}
               </span>

--- a/app/like/_components/StudioCard.tsx
+++ b/app/like/_components/StudioCard.tsx
@@ -73,7 +73,7 @@ export default function StudioCard({ likeStudios, onLikeChange }: StudioCardProp
             {likeStudios.availableSeasons?.map((season, index) => (
               <span
                 key={index}
-                className="text-label2 font-medium text-gray-80 last:border-l last:border-gray-50 last:pl-[0.6rem]"
+                className="border-r border-gray-50 pr-[0.6rem] text-label2 font-medium text-gray-80 last:border-r-0 last:pr-0"
               >
                 {SHOOTING_PERIOD_DISPLAY_MAP[season as ShootingPeriod]}
               </span>

--- a/app/like/page.tsx
+++ b/app/like/page.tsx
@@ -4,7 +4,11 @@ import { getLikeProductsAndStudios } from './actions/like';
 export default async function LikeMainPage({ searchParams }: { searchParams: Promise<{ isSelected?: string }> }) {
   const { products, studios, error } = await getLikeProductsAndStudios();
   const params = await searchParams;
-  const initialTab = params.isSelected === 'product' ? 'product' : 'studio';
+
+  let initialTab = 'product';
+  if (params.isSelected === 'studio') {
+    initialTab = 'studio';
+  }
 
   return (
     <div className="space-y-4">

--- a/app/my/quit/page.tsx
+++ b/app/my/quit/page.tsx
@@ -79,8 +79,7 @@ export default function QuitPage() {
         });
 
         // 로컬 스토리지 정리
-        setStorage('accessToken', '');
-        setStorage('isLoggedIn', 'false');
+        localStorage.clear(); // 로컬 스토리지 정리
         sessionStorage.clear(); // 세션 스토리지 정리
 
         // 쿠키 삭제

--- a/app/products/[id]/_components/ProductDetail.tsx
+++ b/app/products/[id]/_components/ProductDetail.tsx
@@ -98,7 +98,7 @@ export default function ProductDetail({ initProduct, initialError }: ProductDeta
               {product?.availableSeasons.map((season, index) => (
                 <span
                   key={index}
-                  className="text-label2 font-medium text-gray-80 last:border-l last:border-gray-50 last:pl-[0.6rem]"
+                  className="border-r border-gray-50 pr-[0.6rem] text-label2 font-medium text-gray-80 last:border-r-0 last:pr-0"
                 >
                   {season.replace('YEAR_', '').replace('_FIRST_HALF', '년 상반기').replace('_SECOND_HALF', '년 하반기')}
                 </span>
@@ -111,7 +111,7 @@ export default function ProductDetail({ initProduct, initialError }: ProductDeta
               {product?.cameraTypes.map((cameraType, index) => (
                 <span
                   key={index}
-                  className="text-label2 font-medium text-gray-80 last:border-l last:border-gray-50 last:pl-[0.6rem]"
+                  className="border-r border-gray-50 pr-[0.6rem] text-label2 font-medium text-gray-80 last:border-r-0 last:pr-0"
                 >
                   {CAMERA_DISPLAY_MAP[cameraType as CameraType]}
                 </span>


### PR DESCRIPTION
## PR 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 스타일 수정
- [ ] 리팩터링

## 수정 사항

- ProductCard, StudioCard의 날짜옵션(촬영시기), 카메라옵션 상품당 2개이상일 경우 항목 사이 모두 '|' 표시되도록 수정
- 좋아요 페이지 처음 렌더링 시 '찜한 스튜디오'가 아닌 '찜한 상품'이 먼저 focus되도록 수정
- 회원탈퇴 성공 시 localStorage 데이터 남기지말고 clear하도록 수정함
